### PR TITLE
Add support for django 1.4+. Drop support for 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because this implementation sits inside the python interpreter, in a multi-proce
 Requirements
 ------------
 
-* [Django 1.3 or 1.4](https://www.djangoproject.com/download/) with [Postgres](http://www.postgresql.org/)
+* [Django 1.4+](https://www.djangoproject.com/download/) with [Postgres](http://www.postgresql.org/)
 
 
 Installation

--- a/dbpool/db/backends/postgresql_psycopg2/base.py
+++ b/dbpool/db/backends/postgresql_psycopg2/base.py
@@ -222,7 +222,7 @@ django_version = get_django_version()
 if django_version.startswith('1.3'):
     class DatabaseWrapper(DatabaseWrapper13):
         pass
-elif django_version.startswith('1.4'):
+else:
     from django.conf import settings
     from django.db.backends.postgresql_psycopg2.base import utc_tzinfo_factory
     import psycopg2.extensions

--- a/dbpool/db/backends/postgresql_psycopg2/base.py
+++ b/dbpool/db/backends/postgresql_psycopg2/base.py
@@ -229,6 +229,3 @@ else:
 
     class DatabaseWrapper(DatabaseWrapper14):
         pass
-else:
-    raise ImportError("Unsupported Django version %s" % django_version)
-

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        "Django>=1.3",
+        "Django>=1.4",
         "psycopg2>=2.4",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     zip_safe=False,
     install_requires=[
-        "Django>=1.3,<1.4.99",
+        "Django>=1.3",
         "psycopg2>=2.4",
     ],
 )


### PR DESCRIPTION
This would need a carefull look by someone more experienced with connection-pooling software than myself. I did not review the changes (if any?) to django from 1.4 to 1.5  that may affect this package. I'm using it on production (about 500 calls per minute to the db) on django trunk and have not experienced any problems.

I also made a design decision to drop 1.3 support to keep the code size as small as possible. If you still want to support 1.3 I would be happy to make a new pull-request.
