### PR TITLE
Do not to include html and js files in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include AUTHORS README.md LICENSE
-recursive-include dbpool *.py *.html *.js
+recursive-include dbpool *.py


### PR DESCRIPTION
This is to fix pip install complains:
warning: no files found matching '_.html' under directory 'dbpool'
warning: no files found matching '_.js' under directory 'dbpool'
